### PR TITLE
Microphone Button Interface Builder Fix

### DIFF
--- a/Wit/WITMicButton.m
+++ b/Wit/WITMicButton.m
@@ -211,6 +211,11 @@ static const CGFloat kMicMargin = 40.0f;
     return nil;
 }
 
+- (void) didMoveToSuperview {
+    [super didMoveToSuperview];
+    [self recomputePositions];
+}
+
 #pragma mark - KVO
 - (void)observeValueForKeyPath:(NSString *)keyPath
                       ofObject:(id)object


### PR DESCRIPTION
Problem: If you add a UIButton to interface builder and then set it to be WITMicButton, the button isn't rendered. recomputePositions is not being called. 

Solution: This calls recomputePositions when the view is actually added.

Tested with SDK 7.0, autolayout on.
