### PR TITLE
Check for availability of requestWhenInUseAuthorization method

### DIFF
--- a/Wit/WITContextSetter.m
+++ b/Wit/WITContextSetter.m
@@ -52,7 +52,8 @@
         || currentStatus == kCLAuthorizationStatusRestricted) {
         return NO;
     }
-    if (currentStatus == kCLAuthorizationStatusNotDetermined) {
+    if (currentStatus == kCLAuthorizationStatusNotDetermined
+        && [locationManager respondsToSelector:@selector(requestWhenInUseAuthorization)]) {
         [locationManager requestWhenInUseAuthorization];
         currentStatus = [CLLocationManager authorizationStatus];
     }


### PR DESCRIPTION
Check for availability of requestWhenInUseAuthorization method of CLLocationManager
to support iOS versions earlier then 8

Also I would recommend to have setting as detectSpeechStop for the case if I don't want to use location based recognition or I want my app to use locations for other purposes
